### PR TITLE
TMS-1054: Remove hero overlay-toggle from single page editor

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- TMS-1054: Remove hero overlay-toggle from single page editor
+
 ## [1.9.8] - 2024-05-14
 
 - TMS-1029: Change contacts-blocks width

--- a/lib/ACF/AlterPageSettingsFields.php
+++ b/lib/ACF/AlterPageSettingsFields.php
@@ -1,0 +1,42 @@
+<?php
+use TMS\Theme\Base\Logger;
+
+/**
+ * Alter Page settings -fields
+ */
+class AlterPageSettingsFields {
+
+    /**
+     * Constructor
+     */
+    public function __construct() {
+        \add_filter(
+            'tms/acf/group/fg_page_settings',
+            [ $this, 'remove_hero_overlay_setting' ],
+            100
+        );
+    }
+
+
+    /**
+     * Remove overlay TrueFalse-field from page settings
+     *
+     * @param Field\Group[] $fields Array of settings.
+     *
+     * @return array
+     */
+    public function remove_hero_overlay_setting( $group ) {
+        try {
+            if ( $group->get_key() === 'fg_page_settings' ) {
+                $group->remove_field( 'fg_page_settings_remove_overlay' );
+            }
+        }
+        catch ( Exception $e ) {
+            ( new Logger() )->error( $e->getMessage(), $e->getTrace() );
+        }
+
+        return $group;
+    }
+}
+
+( new AlterPageSettingsFields() );

--- a/lib/ACF/AlterPageSettingsFields.php
+++ b/lib/ACF/AlterPageSettingsFields.php
@@ -21,7 +21,7 @@ class AlterPageSettingsFields {
     /**
      * Remove overlay TrueFalse-field from page settings
      *
-     * @param Field\Group[] $fields Array of settings.
+     * @param Field\Group $group Group-object of settings.
      *
      * @return array
      */


### PR DESCRIPTION
Severa-ID: 2108
Severa-kuvaus: TMS-1054 Kampanjateema ja opetuskäytön blogiteema: alasivujen herokuvat
Task: https://hiondigital.atlassian.net/browse/TMS-1054

## Description
Remove hero-images overlay selection from child-themes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
